### PR TITLE
Check if db objects exist before creating

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,99 @@
+name: postgresql-simple-queue
+version: '1.0.0'
+synopsis: A PostgreSQL backed queue
+description: ! 'This module utilize PostgreSQL to implement a durable queue for efficently
+  processing arbitrary payloads which can be represented as JSON.
+
+
+  Typically a producer would enqueue a new payload as part of larger database
+
+  transaction
+
+
+  >  createAccount userRecord = do
+
+  >     ''runDBTSerializable'' $ do
+
+  >        createUserDB userRecord
+
+  >        ''enqueueDB'' "queue_schema" $ makeVerificationEmail userRecord
+
+
+  In another thread or process, the consumer would drain the queue.
+
+
+  >   forever $ do
+
+  >     -- Attempt get a payload or block until one is available
+
+  >     payload <- lock "queue" conn
+
+  >
+
+  >     -- Perform application specifc parsing of the payload value
+
+  >     case fromJSON $ pValue payload of
+
+  >       Success x -> sendEmail x -- Perform application specific processing
+
+  >       Error err -> logErr err
+
+  >
+
+  >     -- Remove the payload from future processing
+
+  >     dequeue "queue" conn $ pId payload
+
+  >
+
+  > To support multiple queues in the same database, the API expects a table name
+  string
+
+  > to determine which queue tables to use.'
+category: Web
+author: Jonathan Fischoff
+maintainer: jonathangfischoff@gmail.com
+copyright: 2017 Jonathan Fischoff
+license: BSD3
+github: jfischoff/postgresql-queue
+extra-source-files:
+- README.md
+ghc-options:
+- -Wall
+- -Wno-unused-do-bind
+
+dependencies:
+- base >=4.7 && <5
+- time
+- transformers
+- random
+- text
+- monad-control
+- exceptions
+- postgresql-simple
+- pg-transact
+- aeson
+- bytestring
+
+library:
+  source-dirs: src
+  exposed-modules:
+  - Database.PostgreSQL.Simple.Queue
+  - Database.PostgreSQL.Simple.Queue.Migrate
+
+tests:
+  unit-tests:
+    main: Spec.hs
+    source-dirs: test
+    ghc-options:
+    - -O2
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - postgresql-simple-queue
+    - hspec
+    - hspec-discover
+    - hspec-expectations-lifted
+    - hspec-pg-transact
+    - async

--- a/package.yaml
+++ b/package.yaml
@@ -74,6 +74,7 @@ dependencies:
 - pg-transact
 - aeson
 - bytestring
+- stm
 
 library:
   source-dirs: src
@@ -97,3 +98,4 @@ tests:
     - hspec-expectations-lifted
     - hspec-pg-transact
     - async
+    - split

--- a/postgresql-simple-queue.cabal
+++ b/postgresql-simple-queue.cabal
@@ -3,7 +3,7 @@
 -- see: https://github.com/sol/hpack
 
 name:           postgresql-simple-queue
-version:        0.5.1.1
+version:        1.0.0
 synopsis:       A PostgreSQL backed queue
 description:    This module utilize PostgreSQL to implement a durable queue for efficently processing arbitrary payloads which can be represented as JSON.
                 .

--- a/postgresql-simple-queue.cabal
+++ b/postgresql-simple-queue.cabal
@@ -69,6 +69,7 @@ library
     , pg-transact
     , aeson
     , bytestring
+    , stm
   default-language: Haskell2010
   ghc-options: -Wall -Wno-unused-do-bind
 
@@ -91,11 +92,13 @@ test-suite unit-tests
     , pg-transact
     , aeson
     , bytestring
+    , stm
     , postgresql-simple-queue
     , hspec
     , hspec-discover
     , hspec-expectations-lifted
     , hspec-pg-transact
     , async
+    , split
   ghc-options: -Wall -Wno-unused-do-bind -O2 -threaded -rtsopts -with-rtsopts=-N
   default-language: Haskell2010

--- a/postgresql-simple-queue.cabal
+++ b/postgresql-simple-queue.cabal
@@ -1,81 +1,101 @@
-name:                postgresql-simple-queue
-version:             0.5.1.1
-synopsis: A PostgreSQL backed queue
-description:
- This module utilize PostgreSQL to implement a durable queue for efficently processing arbitrary payloads which can be represented as JSON.
- .
- Typically a producer would enqueue a new payload as part of larger database
- transaction
- .
- >  createAccount userRecord = do
- >     'runDBTSerializable' $ do
- >        createUserDB userRecord
- >        'enqueueDB' "queue_schema" $ makeVerificationEmail userRecord
- .
- In another thread or process, the consumer would drain the queue.
- .
- >   forever $ do
- >     -- Attempt get a payload or block until one is available
- >     payload <- lock "queue" conn
- >
- >     -- Perform application specifc parsing of the payload value
- >     case fromJSON $ pValue payload of
- >       Success x -> sendEmail x -- Perform application specific processing
- >       Error err -> logErr err
- >
- >     -- Remove the payload from future processing
- >     dequeue "queue" conn $ pId payload
- >
- > To support multiple queues in the same database, the API expects a table name string
- > to determine which queue tables to use.
-homepage:            https://github.com/jfischoff/postgresql-queue#readme
-license:             BSD3
-license-file:        LICENSE
-author:              Jonathan Fischoff
-maintainer:          jonathangfischoff@gmail.com
-copyright:           2017 Jonathan Fischoff
-category:            Web
-build-type:          Simple
-extra-source-files:  README.md
-cabal-version:       >=1.10
+-- This file has been generated from package.yaml by hpack version 0.17.1.
+--
+-- see: https://github.com/sol/hpack
+
+name:           postgresql-simple-queue
+version:        0.5.1.1
+synopsis:       A PostgreSQL backed queue
+description:    This module utilize PostgreSQL to implement a durable queue for efficently processing arbitrary payloads which can be represented as JSON.
+                .
+                Typically a producer would enqueue a new payload as part of larger database
+                transaction
+                .
+                >  createAccount userRecord = do
+                >     'runDBTSerializable' $ do
+                >        createUserDB userRecord
+                >        'enqueueDB' "queue_schema" $ makeVerificationEmail userRecord
+                .
+                In another thread or process, the consumer would drain the queue.
+                .
+                >   forever $ do
+                >     -- Attempt get a payload or block until one is available
+                >     payload <- lock "queue" conn
+                >
+                >     -- Perform application specifc parsing of the payload value
+                >     case fromJSON $ pValue payload of
+                >       Success x -> sendEmail x -- Perform application specific processing
+                >       Error err -> logErr err
+                >
+                >     -- Remove the payload from future processing
+                >     dequeue "queue" conn $ pId payload
+                >
+                > To support multiple queues in the same database, the API expects a table name string
+                > to determine which queue tables to use.
+homepage:       https://github.com/jfischoff/postgresql-queue#readme
+bug-reports:    https://github.com/jfischoff/postgresql-queue/issues
+license:        BSD3
+license-file:   LICENSE
+author:         Jonathan Fischoff
+maintainer:     jonathangfischoff@gmail.com
+copyright:      2017 Jonathan Fischoff
+category:       Web
+build-type:     Simple
+cabal-version:  >= 1.10
+
+extra-source-files:
+    README.md
+
+source-repository head
+  type: git
+  location: https://github.com/jfischoff/postgresql-queue
 
 library
-  hs-source-dirs: src
-  exposed-modules: Database.PostgreSQL.Simple.Queue
-                 , Database.PostgreSQL.Simple.Queue.Migrate
-  build-depends: base >= 4.7 && < 5
-               , postgresql-simple
-               , pg-transact
-               , aeson
-               , time
-               , transformers
-               , random
-               , text
-               , monad-control
-               , exceptions
-               , bytestring
-  default-language:    Haskell2010
+  hs-source-dirs:
+      src
+  exposed-modules:
+      Database.PostgreSQL.Simple.Queue
+      Database.PostgreSQL.Simple.Queue.Migrate
+  other-modules:
+      Paths_postgresql_simple_queue
+  build-depends:
+      base >=4.7 && <5
+    , time
+    , transformers
+    , random
+    , text
+    , monad-control
+    , exceptions
+    , postgresql-simple
+    , pg-transact
+    , aeson
+    , bytestring
+  default-language: Haskell2010
   ghc-options: -Wall -Wno-unused-do-bind
 
 test-suite unit-tests
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+      test
   main-is: Spec.hs
-  other-modules: Database.PostgreSQL.Simple.QueueSpec
-  build-depends: base
-               , postgresql-simple-queue
-               , hspec
-               , hspec-discover
-               , postgresql-simple
-               , pg-transact
-               , bytestring
-               , aeson
-               , hspec-expectations-lifted
-               , hspec-pg-transact
-               , async
+  other-modules:
+      Database.PostgreSQL.Simple.QueueSpec
+  build-depends:
+      base >=4.7 && <5
+    , time
+    , transformers
+    , random
+    , text
+    , monad-control
+    , exceptions
+    , postgresql-simple
+    , pg-transact
+    , aeson
+    , bytestring
+    , postgresql-simple-queue
+    , hspec
+    , hspec-discover
+    , hspec-expectations-lifted
+    , hspec-pg-transact
+    , async
   ghc-options: -Wall -Wno-unused-do-bind -O2 -threaded -rtsopts -with-rtsopts=-N
-  default-language:    Haskell2010
-
-source-repository head
-  type:     git
-  location: https://github.com/jfischoff/postgresql-queue
+  default-language: Haskell2010

--- a/src/Database/PostgreSQL/Simple/Queue.hs
+++ b/src/Database/PostgreSQL/Simple/Queue.hs
@@ -195,7 +195,6 @@ withPayloadDB schemaName retryCount f
       FROM payloads
       WHERE state='enqueued'
       ORDER BY created_at ASC
-             , attempts   ASC
       FOR UPDATE SKIP LOCKED
       LIMIT 1
     |]

--- a/src/Database/PostgreSQL/Simple/Queue.hs
+++ b/src/Database/PostgreSQL/Simple/Queue.hs
@@ -54,16 +54,11 @@ module Database.PostgreSQL.Simple.Queue
   , Payload (..)
   -- * DB API
   , enqueueDB
-  , tryLockDB
-  , unlockDB
-  , dequeueDB
+  , withPayloadDB
   , getCountDB
   -- * IO API
   , enqueue
-  , tryLock
-  , lock
-  , unlock
-  , dequeue
+  , withPayload
   , getCount
   ) where
 import           Control.Monad
@@ -71,7 +66,6 @@ import           Control.Monad.Catch
 import           Data.Aeson
 import           Data.Function
 import           Data.Int
-import           Data.Maybe
 import           Data.Text                               (Text)
 import           Data.Time
 import           Database.PostgreSQL.Simple              (Connection, Only (..))
@@ -86,6 +80,8 @@ import           Database.PostgreSQL.Simple.Transaction
 import           Database.PostgreSQL.Transact
 import           Data.Monoid
 import           Data.String
+import           Control.Monad.IO.Class
+
 -------------------------------------------------------------------------------
 ---  Types
 -------------------------------------------------------------------------------
@@ -98,18 +94,32 @@ instance FromRow PayloadId where
 instance ToRow PayloadId where
   toRow = toRow . Only
 
--- | A 'Payload' can exist in three states in the queue, 'Enqueued', 'Locked'
---   and 'Dequeued'. A 'Payload' starts in the 'Enqueued' state and is 'Locked'
+-- The fundemental record stored in the queue. The queue is a single table
+-- and each row consists of a 'Payload'
+data Payload = Payload
+  { pId         :: PayloadId
+  , pValue      :: Value
+  -- ^ The JSON value of a payload
+  , pState      :: State
+  , pAttempts   :: Int
+  , pCreatedAt  :: UTCTime
+  , pModifiedAt :: UTCTime
+  } deriving (Show, Eq)
+
+instance FromRow Payload where
+  fromRow = Payload <$> field <*> field <*> field <*> field <*> field <*> field
+
+-- | A 'Payload' can exist in three states in the queue, 'Enqueued',
+--   and 'Dequeued'. A 'Payload' starts in the 'Enqueued' state and is locked
 --   so some sort of process can occur with it, usually something in 'IO'.
 --   Once the processing is complete, the `Payload' is moved the 'Dequeued'
 --   state, which is the terminal state.
-data State = Enqueued | Locked | Dequeued
+data State = Enqueued | Dequeued
   deriving (Show, Eq, Ord, Enum, Bounded)
 
 instance ToField State where
   toField = toField . \case
     Enqueued -> "enqueued" :: Text
-    Locked   -> "locked"
     Dequeued -> "dequeued"
 
 -- Converting from enumerations is annoying :(
@@ -120,26 +130,12 @@ instance FromField State where
        Nothing -> returnError UnexpectedNull f "state can't be NULL"
        Just y' -> case y' of
          "enqueued" -> return Enqueued
-         "locked"   -> return Locked
          "dequeued" -> return Dequeued
          x          -> returnError ConversionFailed f (show x)
      else
        returnError Incompatible f $
          "Expect type name to be state but it was " ++ show n
 
--- The fundemental record stored in the queue. The queue is a single table
--- and each row consists of a 'Payload'
-data Payload = Payload
-  { pId         :: PayloadId
-  , pValue      :: Value
-  -- ^ The JSON value of a payload
-  , pState      :: State
-  , pCreatedAt  :: UTCTime
-  , pModifiedAt :: UTCTime
-  } deriving (Show, Eq)
-
-instance FromRow Payload where
-  fromRow = Payload <$> field <*> field <*> field <*> field <*> field
 -------------------------------------------------------------------------------
 ---  DB API
 -------------------------------------------------------------------------------
@@ -161,57 +157,60 @@ notifyName schemaName = fromString $ schemaName <> "_enqueue"
  @
 -}
 enqueueDB :: String -> Value -> DB PayloadId
-enqueueDB schemaName value =
+enqueueDB schemaName value = retryDB schemaName value 0
+
+enqueueWithDB :: String -> Value -> Int -> DB PayloadId
+enqueueWithDB schemaName value attempts =
   fmap head $ query (withSchema schemaName $ [sql|
     NOTIFY |] <> " " <> notifyName schemaName <> ";" <> [sql|
-    INSERT INTO payloads (value)
-    VALUES (?)
+    INSERT INTO payloads (attempts, value)
+    VALUES (?, ?)
     RETURNING id;|]
     )
-    $ Only value
+    $ (attempts + 1, value)
 
-{-| Return a the oldest 'Payload' in the 'Enqueued' state, or 'Nothing'
-    if there are no payloads. This function is not necessarily useful by
-    itself, since there are not many use cases where it needs to be combined
-    with other transactions. See 'tryLock' the IO API version, or for a
-    blocking version utilizing PostgreSQL's NOTIFY and LISTEN, see 'lock'
+retryDB :: String -> Value -> Int -> DB PayloadId
+retryDB schemaName value attempts = enqueueWithDB schemaName value $ attempts + 1
+
+{-|
+
+Attempt to get a payload and send it. If the function passed in throws an exception
+return it on the left side of the `Either`. Re-add the payload up to some passed in
+maximum. Return `Nothing` is the `payloads` table is empty otherwise the result
+of the payload action.
+
 -}
-tryLockDB :: String -> DB (Maybe Payload)
-tryLockDB schemaName = fmap listToMaybe $ query_ $ withSchema schemaName
-  [sql| UPDATE payloads
-        SET state='locked'
-        WHERE id in
-          ( SELECT id
-            FROM payloads
-            WHERE state='enqueued'
-            ORDER BY created_at ASC
-            FOR UPDATE SKIP LOCKED
-            LIMIT 1
-          )
-        RETURNING id, value, state, created_at, modified_at
-  |]
+withPayloadDB :: String -> Int -> (Payload -> IO a) -> DB (Either SomeException (Maybe a))
+withPayloadDB schemaName retryCount f
+  = query_
+    ( withSchema schemaName
+    $ [sql|
+      SELECT id, value, state, attempts, created_at, modified_at
+      FROM payloads
+      WHERE state='enqueued'
+      ORDER BY modified_at ASC
+             , attempts    ASC
+      FOR UPDATE SKIP LOCKED
+      LIMIT 1
+    |]
+    )
+ >>= \case
+    [] -> return $ return Nothing
+    [payload@Payload {..}] -> do
+      execute [sql| UPDATE payloads SET state='dequeued' WHERE id = ? |] pId
 
-{-| Transition a 'Payload' from the 'Locked' state to the 'Enqueued' state.
-    Useful for responding to asynchronous exceptions during a unexpected
-    shutdown. In general the IO API version, 'unlock', is probably more
-    useful. The DB version is provided for completeness.
--}
-unlockDB :: String -> PayloadId -> DB ()
-unlockDB schemaName payloadId = void $ execute (withSchema schemaName
-  [sql| UPDATE payloads
-        SET state='enqueued'
-        WHERE id=? AND state='locked'
-  |])
-  payloadId
-
--- | Transition a 'Payload' to the 'Dequeued' state.
-dequeueDB :: String -> PayloadId -> DB ()
-dequeueDB schemaName payloadId = void $ execute (withSchema schemaName
-  [sql| UPDATE payloads
-        SET state='dequeued'
-        WHERE id=?
-  |])
-  payloadId
+      -- Retry on failure up to retryCount
+      handle (\e -> when (pAttempts < retryCount)
+                         (void $ retryDB schemaName pValue pAttempts)
+                 >> return (Left e)
+             )
+             $ Right . Just <$> liftIO (f payload)
+    xs -> return
+        $ Left
+        $ toException
+        $ userError
+        $ "LIMIT is 1 but got more than one row: "
+        ++ show xs
 
 -- | Get the number of rows in the 'Enqueued' state.
 getCountDB :: String -> DB Int64
@@ -229,14 +228,7 @@ getCountDB schemaName = fmap (fromOnly . head) $ query_ $ withSchema schemaName
 enqueue :: String -> Connection -> Value -> IO PayloadId
 enqueue schemaName conn value = runDBT (enqueueDB schemaName value) ReadCommitted conn
 
-{-| Return a the oldest 'Payload' in the 'Enqueued' state or 'Nothing'
-    if there are no payloads. For a blocking version utilizing PostgreSQL's
-    NOTIFY and LISTEN, see 'lock'. This functions runs 'tryLockDB' as a
-    'Serializable' transaction.
--}
-tryLock :: String -> Connection -> IO (Maybe Payload)
-tryLock schemaName conn = runDBT (tryLockDB schemaName) ReadCommitted conn
-
+-- Block until a payload notification is fired. Fired during insertion.
 notifyPayload :: String -> Connection -> IO ()
 notifyPayload schemaName conn = do
   Notification {..} <- getNotification conn
@@ -247,29 +239,23 @@ notifyPayload schemaName conn = do
     functionality to avoid excessively polling of the DB while
     waiting for new payloads, without scarficing promptness.
 -}
-lock :: String -> Connection -> IO Payload
-lock schemaName conn = bracket_
+withPayload :: String
+            -> Connection
+            -> Int
+            -- ^ retry count
+            -> (Payload -> IO a)
+            -> IO (Either SomeException a)
+withPayload schemaName conn retryCount f = bracket_
   (Simple.execute_ conn $ "LISTEN " <> notifyName schemaName)
   (Simple.execute_ conn $ "UNLISTEN " <> notifyName schemaName)
-  $ fix $ \continue -> do
-      m <- tryLock schemaName conn
-      case m of
-        Nothing -> do
-          notifyPayload schemaName conn
-          continue
-        Just x -> return x
-
-{-| Transition a 'Payload' from the 'Locked' state to the 'Enqueued' state.
-    Useful for responding to asynchronous exceptions during a unexpected
-    shutdown. For a DB API version see 'unlockDB'
--}
-unlock :: String -> Connection -> PayloadId -> IO ()
-unlock schemaName conn x = runDBT  (unlockDB schemaName x) ReadCommitted conn
-
--- | Transition a 'Payload' to the 'Dequeued' state. his functions runs
---   'dequeueDB' as a 'Serializable' transaction.
-dequeue :: String -> Connection -> PayloadId -> IO ()
-dequeue schemaName conn x = runDBT (dequeueDB schemaName x) ReadCommitted conn
+  $ fix
+  $ \continue -> runDBT (withPayloadDB schemaName retryCount f) ReadCommitted conn
+  >>= \case
+    Left x -> return $ Left x
+    Right Nothing -> do
+      notifyPayload schemaName conn
+      continue
+    Right (Just x) -> return $ Right x
 
 {-| Get the number of rows in the 'Enqueued' state. This function runs
     'getCountDB' in a 'ReadCommitted' transaction.

--- a/src/Database/PostgreSQL/Simple/Queue.hs
+++ b/src/Database/PostgreSQL/Simple/Queue.hs
@@ -157,7 +157,7 @@ notifyName schemaName = fromString $ schemaName <> "_enqueue"
  @
 -}
 enqueueDB :: String -> Value -> DB PayloadId
-enqueueDB schemaName value = retryDB schemaName value 0
+enqueueDB schemaName value = enqueueWithDB schemaName value 0
 
 enqueueWithDB :: String -> Value -> Int -> DB PayloadId
 enqueueWithDB schemaName value attempts =
@@ -167,7 +167,7 @@ enqueueWithDB schemaName value attempts =
     VALUES (?, ?)
     RETURNING id;|]
     )
-    $ (attempts + 1, value)
+    $ (attempts, value)
 
 retryDB :: String -> Value -> Int -> DB PayloadId
 retryDB schemaName value attempts = enqueueWithDB schemaName value $ attempts + 1

--- a/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
+++ b/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
@@ -37,9 +37,6 @@ import           Data.String
  language 'plpgsql';
  @
 
-#  CREATE TRIGGER payloads_modified
-#  BEFORE UPDATE ON payloads
-#  FOR EACH ROW EXECUTE PROCEDURE update_row_modified_function();
 -}
 migrate :: String -> Connection -> IO ()
 migrate schemaName conn = void $ execute_ conn $
@@ -72,6 +69,8 @@ migrate schemaName conn = void $ execute_ conn $
   CREATE INDEX active_created_at_attempts_idx ON payloads (created_at, attempts)
     WHERE (state = 'enqueued');
 
-
+  CREATE TRIGGER payloads_modified
+  BEFORE UPDATE ON payloads
+  FOR EACH ROW EXECUTE PROCEDURE update_row_modified_function();
 
   |]

--- a/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
+++ b/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
@@ -36,6 +36,10 @@ import           Data.String
  $$
  language 'plpgsql';
  @
+
+#  CREATE TRIGGER payloads_modified
+#  BEFORE UPDATE ON payloads
+#  FOR EACH ROW EXECUTE PROCEDURE update_row_modified_function();
 -}
 migrate :: String -> Connection -> IO ()
 migrate schemaName conn = void $ execute_ conn $
@@ -68,8 +72,6 @@ migrate schemaName conn = void $ execute_ conn $
   CREATE INDEX active_created_at_attempts_idx ON payloads (created_at, attempts)
     WHERE (state = 'enqueued');
 
-  CREATE TRIGGER payloads_modified
-  BEFORE UPDATE ON payloads
-  FOR EACH ROW EXECUTE PROCEDURE update_row_modified_function();
+
 
   |]

--- a/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
+++ b/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
@@ -43,7 +43,12 @@ migrate schemaName conn = void $ execute_ conn $
   "CREATE SCHEMA IF NOT EXISTS " <> fromString schemaName <> ";" <>
   "SET search_path TO " <> fromString schemaName <> ";" <> [sql|
 
-  CREATE TYPE state_t AS ENUM ('enqueued', 'dequeued');
+  DO $$
+  BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'state_t') THEN
+      CREATE TYPE state_t AS ENUM ('enqueued', 'dequeued');
+    END IF;
+  END$$;
 
   CREATE OR REPLACE FUNCTION update_row_modified_function()
   RETURNS TRIGGER AS
@@ -55,7 +60,7 @@ migrate schemaName conn = void $ execute_ conn $
   $$
   language 'plpgsql';
 
-  CREATE TABLE payloads
+  CREATE TABLE IF NOT EXISTS payloads
   ( id BIGSERIAL PRIMARY KEY
   , value jsonb NOT NULL
   , attempts int NOT NULL DEFAULT 0
@@ -64,11 +69,12 @@ migrate schemaName conn = void $ execute_ conn $
   , modified_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
   );
 
-  CREATE INDEX active_state_idx ON payloads (state)
+  CREATE INDEX IF NOT EXISTS active_state_idx ON payloads (state)
     WHERE (state = 'enqueued');
-  CREATE INDEX active_created_at_idx ON payloads (created_at)
+  CREATE INDEX IF NOT EXISTS active_created_at_idx ON payloads (created_at)
     WHERE (state = 'enqueued');
 
+  DROP TRIGGER IF EXISTS payloads_modified ON payloads;
   CREATE TRIGGER payloads_modified
   BEFORE UPDATE ON payloads
   FOR EACH ROW EXECUTE PROCEDURE update_row_modified_function();

--- a/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
+++ b/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
@@ -65,9 +65,7 @@ migrate schemaName conn = void $ execute_ conn $
 
   CREATE INDEX active_state_idx ON payloads (state)
     WHERE (state = 'enqueued');
-  CREATE INDEX active_attempts_idx ON payloads (attempts)
-    WHERE (state = 'enqueued');
-  CREATE INDEX active_created_at_idx ON payloads (created_at)
+  CREATE INDEX active_created_at_attempts_idx ON payloads (created_at, attempts)
     WHERE (state = 'enqueued');
 
   CREATE TRIGGER payloads_modified

--- a/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
+++ b/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
@@ -66,7 +66,7 @@ migrate schemaName conn = void $ execute_ conn $
 
   CREATE INDEX active_state_idx ON payloads (state)
     WHERE (state = 'enqueued');
-  CREATE INDEX active_created_at_attempts_idx ON payloads (created_at, attempts)
+  CREATE INDEX active_created_at_idx ON payloads (created_at)
     WHERE (state = 'enqueued');
 
   CREATE TRIGGER payloads_modified

--- a/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
+++ b/src/Database/PostgreSQL/Simple/Queue/Migrate.hs
@@ -41,29 +41,37 @@ migrate :: String -> Connection -> IO ()
 migrate schemaName conn = void $ execute_ conn $
   "CREATE SCHEMA IF NOT EXISTS " <> fromString schemaName <> ";" <>
   "SET search_path TO " <> fromString schemaName <> ";" <> [sql|
-  CREATE TYPE state_t AS ENUM ('enqueued', 'locked', 'dequeued');
 
-  CREATE TABLE payloads
-  ( id SERIAL PRIMARY KEY
-  , value jsonb NOT NULL
-  , state state_t NOT NULL DEFAULT 'enqueued'
-  , created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
-  , modified_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
-  );
+  CREATE TYPE state_t AS ENUM ('enqueued', 'dequeued');
 
-  CREATE INDEX state_idx ON payloads (state);
-
-  CREATE OR REPLACE FUNCTION update_row_modified_function_()
-  RETURNS TRIGGER
-  AS
+  CREATE OR REPLACE FUNCTION update_row_modified_function()
+  RETURNS TRIGGER AS
   $$
   BEGIN
-      -- ASSUMES the table has a column named exactly "modified_at".
-      -- Fetch date-time of actual current moment from clock,
-      -- rather than start of statement or start of transaction.
       NEW.modified_at = clock_timestamp();
       RETURN NEW;
   END;
   $$
   language 'plpgsql';
+
+  CREATE TABLE payloads
+  ( id BIGSERIAL PRIMARY KEY
+  , value jsonb NOT NULL
+  , attempts int NOT NULL DEFAULT 0
+  , state state_t NOT NULL DEFAULT 'enqueued'
+  , created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+  , modified_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp()
+  );
+
+  CREATE INDEX active_state_idx ON payloads (state)
+    WHERE (state = 'enqueued');
+  CREATE INDEX active_attempts_idx ON payloads (attempts)
+    WHERE (state = 'enqueued');
+  CREATE INDEX active_created_at_idx ON payloads (created_at)
+    WHERE (state = 'enqueued');
+
+  CREATE TRIGGER payloads_modified
+  BEFORE UPDATE ON payloads
+  FOR EACH ROW EXECUTE PROCEDURE update_row_modified_function();
+
   |]

--- a/stack.yaml
+++ b/stack.yaml
@@ -37,7 +37,6 @@ resolver: nightly-2017-11-10
 # will not be run. This is useful for tweaking upstream packages.
 packages:
 - '.'
-- 'pg-transact-hspec'
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)

--- a/stack.yaml
+++ b/stack.yaml
@@ -37,10 +37,17 @@ resolver: nightly-2017-11-10
 # will not be run. This is useful for tweaking upstream packages.
 packages:
 - '.'
+- 'pg-transact-hspec'
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: ['hspec-pg-transact-0.1.0.2', 'tmp-postgres-0.1.0.7', 'hspec-expectations-lifted-0.10.0', 'optparse-generic-1.2.2', 'pg-transact-0.1.0.1', 'postgresql-simple-opts-0.2.0.2']
+extra-deps:
+  - 'hspec-pg-transact-0.1.0.2'
+  - 'tmp-postgres-0.1.0.7'
+  - 'hspec-expectations-lifted-0.10.0'
+  - 'optparse-generic-1.2.2'
+  - 'pg-transact-0.1.0.1'
+  - 'postgresql-simple-opts-0.2.0.2'
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-8.23
+resolver: nightly-2017-11-10
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/Database/PostgreSQL/Simple/QueueSpec.hs
+++ b/test/Database/PostgreSQL/Simple/QueueSpec.hs
@@ -119,10 +119,6 @@ spec = describeDB (migrate schemaName) "Database.Queue" $ do
 
       when (lastCount < elementCount) next
 
-    -- Fork a hundred threads and enqueue an index
-    -- forM_ [0 .. elementCount - 1] $ \i -> forkIO $ void $ withPool' $ \c ->
-    --  enqueue schemaName c $ toJSON i
-
     forM_ (chunksOf (elementCount `div` 40) expected) $ \xs -> forkIO $ void $ withPool' $ \c ->
        forM_ xs $ \i -> enqueue schemaName c $ toJSON i
 

--- a/test/Database/PostgreSQL/Simple/QueueSpec.hs
+++ b/test/Database/PostgreSQL/Simple/QueueSpec.hs
@@ -2,11 +2,11 @@
 {-# LANGUAGE RecordWildCards   #-}
 module Database.PostgreSQL.Simple.QueueSpec (spec, main) where
 import           Control.Concurrent
+import           Control.Concurrent.STM
 import           Control.Concurrent.Async
 import           Control.Monad
 import           Data.Aeson
 import           Data.Function
-import           Data.IORef
 import           Data.List
 import           Database.PostgreSQL.Simple.Queue
 import           Database.PostgreSQL.Simple.Queue.Migrate
@@ -14,6 +14,8 @@ import           Test.Hspec                     (Spec, hspec, it)
 import           Test.Hspec.Expectations.Lifted
 import           Test.Hspec.DB
 import           Control.Monad.Catch
+import           Data.List.Split
+
 
 main :: IO ()
 main = hspec spec
@@ -48,23 +50,32 @@ spec = describeDB (migrate schemaName) "Database.Queue" $ do
 
   it "enqueues and dequeues concurrently withPayload" $ \testDB -> do
     let withPool' = withPool testDB
-        elementCount = 1000 :: Int
+        elementCount = 10000 :: Int
         expected = [0 .. elementCount - 1]
 
-    ref <- newIORef []
+    ref <- newTVarIO []
 
     loopThreads <- replicateM 10 $ async $ fix $ \next -> do
-      lastCount <- either throwM return =<< withPool' (\c -> withPayload schemaName c 8 $ \(Payload {..}) -> do
-        atomicModifyIORef ref $ \xs -> (pValue : xs, length xs + 1)
+      lastCount <- either throwM return =<< withPool' (\c -> withPayload schemaName c 0 $ \(Payload {..}) -> do
+        atomically $ do
+          xs <- readTVar ref
+          writeTVar ref $ pValue : xs
+          return $ length xs + 1
         )
 
       when (lastCount < elementCount) next
 
     -- Fork a hundred threads and enqueue an index
-    forM_ [0 .. elementCount - 1] $ \i -> forkIO $ void $ withPool' $ \c ->
-      enqueue schemaName c $ toJSON i
+    -- forM_ [0 .. elementCount - 1] $ \i -> forkIO $ void $ withPool' $ \c ->
+    --  enqueue schemaName c $ toJSON i
+
+    forM_ (chunksOf (elementCount `div` 40) expected) $ \xs -> forkIO $ void $ withPool' $ \c ->
+       forM_ xs $ \i -> enqueue schemaName c $ toJSON i
+
 
     waitAnyCancel loopThreads
-    xs <- readIORef ref
+    xs <- atomically $ readTVar ref
     let Just decoded = mapM (decode . encode) xs
     sort decoded `shouldBe` sort expected
+
+  --  threadDelay maxBound

--- a/test/Database/PostgreSQL/Simple/QueueSpec.hs
+++ b/test/Database/PostgreSQL/Simple/QueueSpec.hs
@@ -50,7 +50,7 @@ spec = describeDB (migrate schemaName) "Database.Queue" $ do
 
   it "enqueues and dequeues concurrently withPayload" $ \testDB -> do
     let withPool' = withPool testDB
-        elementCount = 10000 :: Int
+        elementCount = 1000 :: Int
         expected = [0 .. elementCount - 1]
 
     ref <- newTVarIO []


### PR DESCRIPTION
This helps in my app where I call `migrate` at application startup. I was getting an error when `migrate` attempted to create `state_t` again.